### PR TITLE
Fixes "Too many open files"

### DIFF
--- a/src/clodyx/qrcraft/QRcraftPlugIn.php
+++ b/src/clodyx/qrcraft/QRcraftPlugIn.php
@@ -45,10 +45,7 @@ class QRcraftPlugIn extends PluginBase implements CommandExecutor
 
     public function loadConfiguration()
     {
-        if (!file_exists($this->getDataFolder() . "config.yml")) {
-            @mkdir($this->getDataFolder());
-            file_put_contents($this->getDataFolder() . "config.yml", $this->getResource("config.yml"));
-        }
+        $this->saveDefaultConfig();
     }
 
     public function onDisable()


### PR DESCRIPTION
This fixes issues with not closing resources given by PocketMine, causing a crash at a later stage.
Users usually blame PocketMine for this, but it's entirely a plugin's fault.

This code was found via GitHub search, please review your code for usage of:
- `Plugin->getResource()` without `fclose()` calls later
- Not needed `Plugin->getResource()` calls
- `fopen()` calls without `fclose()`
- `popen()` calls without `pclose()`
